### PR TITLE
compatible with gii class generator

### DIFF
--- a/model/Generator.php
+++ b/model/Generator.php
@@ -146,7 +146,7 @@ class Generator extends \yii\gii\generators\model\Generator
      *
      * @return string the generated class name
      */
-    protected function generateClassName($tableName)
+    protected function generateClassName($tableName, $useSchemaName = NULL)
     {
 
         #Yii::trace("Generating class name for '{$tableName}'...", __METHOD__);


### PR DESCRIPTION
Declaration of veyselsahin\giix\model\Generator::generateClassName($tableName) should be compatible with yii\gii\generators\model\Generator::generateClassName($tableName, $useSchemaName = NULL)